### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: timecardassistant
 Type: Package
 Title: Assists In The Creating Of Timecards
-Version: 0.0.0.9550
+Version: 0.0.0.9551
 Author: Ben Woodard
 Maintainer: Ben Woodard <ben.woodard@searchdiscovery.com>
 Description: Use this package to assist you in keeping track of your time.

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,0 +1,6 @@
+.onLoad <- function(libname, pkgname) {
+  .auth <<- gargle::init_AuthState(
+    package     = "gcal",
+    auth_active = TRUE
+  )
+}

--- a/R/gcalendr_auth.R
+++ b/R/gcalendr_auth.R
@@ -10,10 +10,8 @@ calendar_app <- function() {
   )
 }
 options(gargle_oauth_email = TRUE)
-.auth <- gargle::init_AuthState(
-  package     = "gcal",
-  auth_active = TRUE
-)
+# Initialized in .onLoad.
+.auth <- NULL
 
 # The roxygen comments for these functions are mostly generated from data
 # in this list and template text maintained in gargle.


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for r-lib/gargle#157, but is a good change even without that PR.